### PR TITLE
Update Gpprefdecrypt.py: explicit IV in AES.new

### DIFF
--- a/Gpprefdecrypt.py
+++ b/Gpprefdecrypt.py
@@ -26,7 +26,7 @@ cpassword += "=" * ((4 - len(sys.argv[1]) % 4) % 4)
 password = b64decode(cpassword)
 
 # Decrypt the password
-o = AES.new(key, AES.MODE_CBC).decrypt(password)
+o = AES.new(key, AES.MODE_CBC, "\x00" * 16).decrypt(password)
 
 # Print it
 print o[:-ord(o[-1])].decode('utf16')


### PR DESCRIPTION
Crypto.Cipher.AES now requires explicit IV specification and throws an exception if it is not specified. The script was broken because of that.